### PR TITLE
fix: synchronize audio/video tfdt shifts to prevent A/V desync

### DIFF
--- a/chaturbate/chaturbate.go
+++ b/chaturbate/chaturbate.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"sort"
 	"strconv"
@@ -669,12 +670,24 @@ func (p *Playlist) watchMuxedSegments(ctx context.Context, handler WatchHandler)
 	initWritten := false
 	consecutiveErrors := 0
 
-	// Per-track tfdt base times captured from the first segment of each track.
-	// Subtracting these normalises timestamps to start from zero.
+	// Per-track tfdt base times and timescales captured from init/first segments.
+	// videoShift/audioShift are the synchronized shifts computed once both bases
+	// are known; they align both tracks to the same real-time presentation origin.
+	var videoTimescale, audioTimescale uint64
 	var videoTimeBase uint64
 	var audioTimeBase uint64
 	videoBaseSet := false
 	audioBaseSet := false
+	var syncBaseComputed bool
+	var videoShift, audioShift uint64
+
+	// pendingChunk buffers raw (unshifted) segment bytes before sync is computed.
+	type pendingChunk struct {
+		rawVideo []byte
+		rawAudio []byte
+		duration float64
+	}
+	var pendingChunks []pendingChunk
 
 	for {
 		// Fetch video playlist
@@ -742,6 +755,16 @@ func (p *Playlist) watchMuxedSegments(ctx context.Context, handler WatchHandler)
 				videoInitBytes = b
 				lastVideoMapURI = v.Map.URI
 				initWritten = false
+				syncBaseComputed = false // re-sync after init change
+				videoBaseSet = false
+				audioBaseSet = false
+				pendingChunks = nil
+				if ts, ok := extractTimescaleFromInit(b); ok {
+					videoTimescale = ts
+					fmt.Printf("[sync] muxed: video init timescale=%d\n", ts)
+				} else {
+					fmt.Printf("[sync] muxed: video init timescale=unknown (parse failed)\n")
+				}
 			}
 			break
 		}
@@ -760,6 +783,12 @@ func (p *Playlist) watchMuxedSegments(ctx context.Context, handler WatchHandler)
 				audioInitBytes = b
 				lastAudioMapURI = v.Map.URI
 				initWritten = false
+				if ts, ok := extractTimescaleFromInit(b); ok {
+					audioTimescale = ts
+					fmt.Printf("[sync] muxed: audio init timescale=%d\n", ts)
+				} else {
+					fmt.Printf("[sync] muxed: audio init timescale=unknown (parse failed)\n")
+				}
 			}
 			break
 		}
@@ -852,14 +881,46 @@ func (p *Playlist) watchMuxedSegments(ctx context.Context, handler WatchHandler)
 			if len(newAudioSegs) > maxLen {
 				maxLen = len(newAudioSegs)
 			}
+
+			// computeSyncShifts sets videoShift/audioShift to a common presentation
+			// origin derived from real-time seconds so both tracks stay in sync.
+			computeSyncShifts := func() {
+				if videoTimescale > 0 && audioTimescale > 0 {
+					videoStart := float64(videoTimeBase) / float64(videoTimescale)
+					audioStart := float64(audioTimeBase) / float64(audioTimescale)
+					minStart := videoStart
+					if audioStart < minStart {
+						minStart = audioStart
+					}
+					videoShift = videoTimeBase - uint64(math.Round(minStart*float64(videoTimescale)))
+					audioShift = audioTimeBase - uint64(math.Round(minStart*float64(audioTimescale)))
+					fmt.Printf("[sync] muxed: video tfdt=%d ts=%d (%.6fs)  audio tfdt=%d ts=%d (%.6fs)  minStart=%.6fs  videoShift=%d audioShift=%d drift=%.3fms\n",
+						videoTimeBase, videoTimescale, videoStart,
+						audioTimeBase, audioTimescale, audioStart,
+						minStart, videoShift, audioShift,
+						(videoStart-audioStart)*1000,
+					)
+				} else {
+					videoShift = videoTimeBase
+					audioShift = audioTimeBase
+					fmt.Printf("[sync] muxed: timescales unknown, using raw bases videoShift=%d audioShift=%d\n", videoShift, audioShift)
+				}
+				syncBaseComputed = true
+				fmt.Printf("[sync] muxed: flushing %d buffered segment(s)\n", len(pendingChunks))
+				// pendingChunks are flushed by the caller after this returns.
+			}
+
 			for i := 0; i < maxLen; i++ {
-				var chunk []byte
-				var chunkDuration float64
+				// Collect raw bytes without shifting so the synchronized shift
+				// can be applied once both track bases are known.
+				var rawVideo []byte
+				var videoDur float64
+				var rawAudio []byte
 
 				if i < len(newVideoSegs) {
 					vseg := newVideoSegs[i]
 					vsegURL := vseg.url
-					segBytes, err := retry.DoWithData(
+					b, err := retry.DoWithData(
 						func() ([]byte, error) { return client.GetBytes(ctx, vsegURL) },
 						retry.Context(ctx),
 						retry.Attempts(3),
@@ -867,21 +928,21 @@ func (p *Playlist) watchMuxedSegments(ctx context.Context, handler WatchHandler)
 						retry.DelayType(retry.FixedDelay),
 					)
 					if err == nil {
+						rawVideo = b
+						videoDur = vseg.duration
 						if !videoBaseSet {
-							if t, ok := extractMoofFirstTfdt(segBytes); ok {
+							if t, ok := extractMoofFirstTfdt(b); ok {
 								videoTimeBase = t
 								videoBaseSet = true
+								fmt.Printf("[sync] muxed: video first tfdt=%d\n", t)
 							}
 						}
-						segBytes = shiftSegmentTfdt(segBytes, 1, videoTimeBase)
-						chunk = append(chunk, segBytes...)
-						chunkDuration = vseg.duration
 					}
 				}
 				if i < len(newAudioSegs) {
 					aseg := newAudioSegs[i]
 					asegURL := aseg.url
-					segBytes, err := retry.DoWithData(
+					b, err := retry.DoWithData(
 						func() ([]byte, error) { return client.GetBytes(ctx, asegURL) },
 						retry.Context(ctx),
 						retry.Attempts(3),
@@ -891,31 +952,60 @@ func (p *Playlist) watchMuxedSegments(ctx context.Context, handler WatchHandler)
 					if err != nil {
 						fmt.Printf("[WARN] audio seg download failed: %v\n", err)
 					} else {
+						rawAudio = b
 						if !audioBaseSet {
-							if t, ok := extractMoofFirstTfdt(segBytes); ok {
+							if t, ok := extractMoofFirstTfdt(b); ok {
 								audioTimeBase = t
 								audioBaseSet = true
-								if server.Config.Debug {
-									fmt.Printf("[DEBUG] muxed: audio base=%d\n", audioTimeBase)
-								}
+								fmt.Printf("[sync] muxed: audio first tfdt=%d\n", t)
 							}
 						}
-						if server.Config.Debug {
-							if rawTfdt, ok := extractMoofFirstTfdt(segBytes); ok {
-								var normalised uint64
-								if audioTimeBase > 0 && rawTfdt >= audioTimeBase {
-									normalised = rawTfdt - audioTimeBase
-								}
-								fmt.Printf("[DEBUG] muxed: audio seg dur=%.3f raw_tfdt=%d norm=%d\n", aseg.duration, rawTfdt, normalised)
-							}
-						}
-						segBytes = rewriteAudioMoofTrackID(segBytes)
-						segBytes = shiftSegmentTfdt(segBytes, 2, audioTimeBase)
-						chunk = append(chunk, segBytes...)
 					}
 				}
+
+				// Compute synchronized shifts once both track bases are known.
+				if !syncBaseComputed && videoBaseSet && audioBaseSet {
+					computeSyncShifts()
+					// Flush segments buffered before sync was computed.
+					for _, pc := range pendingChunks {
+						var chunk []byte
+						if pc.rawVideo != nil {
+							chunk = append(chunk, shiftSegmentTfdt(pc.rawVideo, 1, videoShift)...)
+						}
+						if pc.rawAudio != nil {
+							a := rewriteAudioMoofTrackID(pc.rawAudio)
+							a = shiftSegmentTfdt(a, 2, audioShift)
+							chunk = append(chunk, a...)
+						}
+						if len(chunk) > 0 {
+							if err := handler(chunk, pc.duration); err != nil {
+								return fmt.Errorf("handler buffered muxed segment: %w", err)
+							}
+						}
+					}
+					pendingChunks = nil
+				}
+
+				if rawVideo == nil && rawAudio == nil {
+					continue
+				}
+				if !syncBaseComputed {
+					// Buffer until both track bases are available.
+					pendingChunks = append(pendingChunks, pendingChunk{rawVideo: rawVideo, rawAudio: rawAudio, duration: videoDur})
+					continue
+				}
+
+				var chunk []byte
+				if rawVideo != nil {
+					chunk = append(chunk, shiftSegmentTfdt(rawVideo, 1, videoShift)...)
+				}
+				if rawAudio != nil {
+					a := rewriteAudioMoofTrackID(rawAudio)
+					a = shiftSegmentTfdt(a, 2, audioShift)
+					chunk = append(chunk, a...)
+				}
 				if len(chunk) > 0 {
-					if err := handler(chunk, chunkDuration); err != nil {
+					if err := handler(chunk, videoDur); err != nil {
 						return fmt.Errorf("handler muxed segment group: %w", err)
 					}
 				}
@@ -947,21 +1037,15 @@ func (p *Playlist) watchMuxedSegments(ctx context.Context, handler WatchHandler)
 				fmt.Printf("[WARN] video seg download failed: %v\n", err)
 				continue
 			}
-
 			rawTfdt, ok := extractMoofFirstTfdt(segBytes)
 			if !videoBaseSet && ok {
 				videoTimeBase = rawTfdt
 				videoBaseSet = true
+				fmt.Printf("[sync] stripchat: video first tfdt=%d\n", rawTfdt)
 			}
-
-			normalisedTime := rawTfdt
-			if videoBaseSet && rawTfdt >= videoTimeBase {
-				normalisedTime = rawTfdt - videoTimeBase
-			}
-			segBytes = shiftSegmentTfdt(segBytes, 1, videoTimeBase)
 			pending = append(pending, pendingSeg{
 				track:    "video",
-				time:     normalisedTime,
+				time:     rawTfdt,
 				duration: vseg.duration,
 				data:     segBytes,
 			})
@@ -980,32 +1064,63 @@ func (p *Playlist) watchMuxedSegments(ctx context.Context, handler WatchHandler)
 				fmt.Printf("[WARN] audio seg download failed: %v\n", err)
 				continue
 			}
-
 			rawTfdt, ok := extractMoofFirstTfdt(segBytes)
 			if !audioBaseSet && ok {
 				audioTimeBase = rawTfdt
 				audioBaseSet = true
-				if server.Config.Debug {
-					fmt.Printf("[DEBUG] muxed: audio base=%d\n", audioTimeBase)
-				}
+				fmt.Printf("[sync] stripchat: audio first tfdt=%d\n", rawTfdt)
 			}
-
-			normalisedTime := rawTfdt
-			if audioBaseSet && rawTfdt >= audioTimeBase {
-				normalisedTime = rawTfdt - audioTimeBase
-			}
-			if server.Config.Debug && ok {
-				fmt.Printf("[DEBUG] muxed: audio seg dur=%.3f raw_tfdt=%d norm=%d\n", aseg.duration, rawTfdt, normalisedTime)
-			}
-
 			segBytes = rewriteAudioMoofTrackID(segBytes)
-			segBytes = shiftSegmentTfdt(segBytes, 2, audioTimeBase)
 			pending = append(pending, pendingSeg{
 				track:    "audio",
-				time:     normalisedTime,
+				time:     rawTfdt,
 				duration: 0,
 				data:     segBytes,
 			})
+		}
+
+		// Compute synchronized shifts once both bases are known.
+		if !syncBaseComputed && videoBaseSet && audioBaseSet {
+			if videoTimescale > 0 && audioTimescale > 0 {
+				videoStart := float64(videoTimeBase) / float64(videoTimescale)
+				audioStart := float64(audioTimeBase) / float64(audioTimescale)
+				minStart := videoStart
+				if audioStart < minStart {
+					minStart = audioStart
+				}
+				videoShift = videoTimeBase - uint64(math.Round(minStart*float64(videoTimescale)))
+				audioShift = audioTimeBase - uint64(math.Round(minStart*float64(audioTimescale)))
+				fmt.Printf("[sync] stripchat: video tfdt=%d ts=%d (%.6fs)  audio tfdt=%d ts=%d (%.6fs)  minStart=%.6fs  videoShift=%d audioShift=%d drift=%.3fms\n",
+					videoTimeBase, videoTimescale, videoStart,
+					audioTimeBase, audioTimescale, audioStart,
+					minStart, videoShift, audioShift,
+					(videoStart-audioStart)*1000,
+				)
+			} else {
+				videoShift = videoTimeBase
+				audioShift = audioTimeBase
+				fmt.Printf("[sync] stripchat: timescales unknown, using raw bases videoShift=%d audioShift=%d\n", videoShift, audioShift)
+			}
+			syncBaseComputed = true
+		}
+
+		// Apply synchronized shifts and sort by adjusted presentation time.
+		for i := range pending {
+			if pending[i].track == "video" {
+				normTime := pending[i].time
+				if syncBaseComputed && normTime >= videoShift {
+					normTime -= videoShift
+				}
+				pending[i].time = normTime
+				pending[i].data = shiftSegmentTfdt(pending[i].data, 1, videoShift)
+			} else {
+				normTime := pending[i].time
+				if syncBaseComputed && normTime >= audioShift {
+					normTime -= audioShift
+				}
+				pending[i].time = normTime
+				pending[i].data = shiftSegmentTfdt(pending[i].data, 2, audioShift)
+			}
 		}
 
 		sort.SliceStable(pending, func(i, j int) bool {

--- a/chaturbate/mux.go
+++ b/chaturbate/mux.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"sort"
 )
@@ -377,10 +378,10 @@ func BuildSeekIndex(path string) error {
 	}
 
 	trackEntries := map[uint32][]tfraEntry{} // track_id -> entries
+	trackTimescales := map[uint32]uint64{}   // track_id -> timescale from moov
 	var patches []tfdtPatch
 
-	// Pass 1: walk top-level boxes by reading 8-byte headers and seeking.
-	// Only moof boxes are read into memory (typically a few KB each).
+	// Pass 1: walk top-level boxes by reading 8-byte headers; load moov and moof boxes.
 	var pos int64
 	hdr := make([]byte, 8)
 	for pos+8 <= fileSize {
@@ -396,7 +397,12 @@ func BuildSeekIndex(path string) error {
 		if boxType == "mfra" {
 			return nil // already indexed
 		}
-
+		if boxType == "moov" {
+			moovData := make([]byte, size-8)
+			if _, err := f.ReadAt(moovData, pos+8); err == nil {
+				extractTrackTimescales(moovData, trackTimescales)
+			}
+		}
 		if boxType == "moof" {
 			moofData := make([]byte, size-8)
 			if _, err := f.ReadAt(moofData, pos+8); err != nil {
@@ -418,16 +424,47 @@ func BuildSeekIndex(path string) error {
 		return nil
 	}
 
-	// Compute per-track minimum baseMediaDecodeTime.
-	minTimes := map[uint32]uint64{}
+	// Normalise all tracks relative to a common presentation origin to preserve
+	// A/V sync. Convert each track's first tfdt to seconds using its timescale,
+	// find the global minimum in seconds, then compute each track's raw shift as
+	// trackMin - round(globalMinSec * timescale). This mirrors exactly what the
+	// recorder does during live capture.
+	type trackInfo struct {
+		minTime   uint64
+		timescale uint64
+	}
+	infos := map[uint32]trackInfo{}
 	for id, entries := range trackEntries {
-		min := entries[0].time
+		trackMin := entries[0].time
 		for _, e := range entries[1:] {
-			if e.time < min {
-				min = e.time
+			if e.time < trackMin {
+				trackMin = e.time
 			}
 		}
-		minTimes[id] = min
+		ts := trackTimescales[id]
+		if ts == 0 {
+			ts = 90000 // safe fallback
+		}
+		infos[id] = trackInfo{minTime: trackMin, timescale: ts}
+	}
+
+	// Find the minimum start time in seconds across all tracks.
+	globalMinSec := -1.0
+	for _, info := range infos {
+		sec := float64(info.minTime) / float64(info.timescale)
+		if globalMinSec < 0 || sec < globalMinSec {
+			globalMinSec = sec
+		}
+	}
+
+	minTimes := map[uint32]uint64{}
+	for id, info := range infos {
+		// Amount to subtract so this track's origin aligns to globalMinSec.
+		shift := uint64(math.Round(globalMinSec * float64(info.timescale)))
+		if shift > info.minTime {
+			shift = info.minTime // safety: never underflow
+		}
+		minTimes[id] = shift
 	}
 
 	// Pass 2: patch tfdt values in-place using pwrite (no full-file rewrite).
@@ -478,6 +515,63 @@ func BuildSeekIndex(path string) error {
 		return fmt.Errorf("write mfra: %w", err)
 	}
 	return nil
+}
+
+// extractTrackTimescales reads a moov box's content (without its 8-byte header)
+// and populates timescales with the mdhd.timescale for each trak's track_id.
+func extractTrackTimescales(moovContent []byte, timescales map[uint32]uint64) {
+	boxes, _ := parseMP4Boxes(moovContent)
+	for _, b := range boxes {
+		if b.typ != "trak" {
+			continue
+		}
+		trakContent := b.data[8:]
+		// read track_id from tkhd
+		var trackID uint32
+		trakBoxes, _ := parseMP4Boxes(trakContent)
+		for _, tb := range trakBoxes {
+			if tb.typ == "tkhd" && len(tb.data) >= 9 {
+				version := tb.data[8]
+				var idOff int
+				if version == 0 {
+					idOff = 20
+				} else {
+					idOff = 28
+				}
+				if idOff+4 <= len(tb.data) {
+					trackID = binary.BigEndian.Uint32(tb.data[idOff:])
+				}
+				break
+			}
+		}
+		if trackID == 0 {
+			continue
+		}
+		// read timescale from mdia > mdhd
+		for _, tb := range trakBoxes {
+			if tb.typ != "mdia" {
+				continue
+			}
+			mdiaBoxes, _ := parseMP4Boxes(tb.data[8:])
+			for _, mb := range mdiaBoxes {
+				if mb.typ == "mdhd" && len(mb.data) >= 9 {
+					version := mb.data[8]
+					var tsOff int
+					if version == 0 {
+						tsOff = 20
+					} else {
+						tsOff = 28
+					}
+					if tsOff+4 <= len(mb.data) {
+						ts := uint64(binary.BigEndian.Uint32(mb.data[tsOff:]))
+						if ts > 0 {
+							timescales[trackID] = ts
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 // scanMoofForIndex parses moof content (without the 8-byte box header) and
@@ -584,46 +678,6 @@ func normaliseTfdt(data []byte, minTimes map[uint32]uint64) {
 		}
 		pos += size
 	}
-}
-
-// extractTimescaleFromInit returns the timescale for the first track found in an
-// fMP4 init segment (moov > trak > mdia > mdhd.timescale). Returns 0, false on
-// any parse failure.
-func extractTimescaleFromInit(data []byte) (uint64, bool) {
-	moovBox, ok := findMP4Box(data, "moov")
-	if !ok {
-		return 0, false
-	}
-	trakBox, ok := findMP4Box(moovBox[8:], "trak")
-	if !ok {
-		return 0, false
-	}
-	mdiaBox, ok := findMP4Box(trakBox[8:], "mdia")
-	if !ok {
-		return 0, false
-	}
-	mdhdBox, ok := findMP4Box(mdiaBox[8:], "mdhd")
-	if !ok {
-		return 0, false
-	}
-	// mdhd layout (full box including 8-byte size+type header):
-	//   [8]      version
-	//   [9:12]   flags
-	//   version 0: [12:16] creation, [16:20] modification, [20:24] timescale
-	//   version 1: [12:20] creation, [20:28] modification, [28:32] timescale
-	if len(mdhdBox) < 9 {
-		return 0, false
-	}
-	version := mdhdBox[8]
-	if version == 0 && len(mdhdBox) >= 24 {
-		ts := uint64(binary.BigEndian.Uint32(mdhdBox[20:]))
-		return ts, ts > 0
-	}
-	if version == 1 && len(mdhdBox) >= 32 {
-		ts := uint64(binary.BigEndian.Uint32(mdhdBox[28:]))
-		return ts, ts > 0
-	}
-	return 0, false
 }
 
 // extractMoofFirstTfdt returns the baseMediaDecodeTime from the first moof found

--- a/chaturbate/mux.go
+++ b/chaturbate/mux.go
@@ -586,6 +586,46 @@ func normaliseTfdt(data []byte, minTimes map[uint32]uint64) {
 	}
 }
 
+// extractTimescaleFromInit returns the timescale for the first track found in an
+// fMP4 init segment (moov > trak > mdia > mdhd.timescale). Returns 0, false on
+// any parse failure.
+func extractTimescaleFromInit(data []byte) (uint64, bool) {
+	moovBox, ok := findMP4Box(data, "moov")
+	if !ok {
+		return 0, false
+	}
+	trakBox, ok := findMP4Box(moovBox[8:], "trak")
+	if !ok {
+		return 0, false
+	}
+	mdiaBox, ok := findMP4Box(trakBox[8:], "mdia")
+	if !ok {
+		return 0, false
+	}
+	mdhdBox, ok := findMP4Box(mdiaBox[8:], "mdhd")
+	if !ok {
+		return 0, false
+	}
+	// mdhd layout (full box including 8-byte size+type header):
+	//   [8]      version
+	//   [9:12]   flags
+	//   version 0: [12:16] creation, [16:20] modification, [20:24] timescale
+	//   version 1: [12:20] creation, [20:28] modification, [28:32] timescale
+	if len(mdhdBox) < 9 {
+		return 0, false
+	}
+	version := mdhdBox[8]
+	if version == 0 && len(mdhdBox) >= 24 {
+		ts := uint64(binary.BigEndian.Uint32(mdhdBox[20:]))
+		return ts, ts > 0
+	}
+	if version == 1 && len(mdhdBox) >= 32 {
+		ts := uint64(binary.BigEndian.Uint32(mdhdBox[28:]))
+		return ts, ts > 0
+	}
+	return 0, false
+}
+
 // extractMoofFirstTfdt returns the baseMediaDecodeTime from the first moof found
 // in data (a raw fMP4 segment). Returns (0, false) if not found.
 func extractMoofFirstTfdt(data []byte) (uint64, bool) {


### PR DESCRIPTION
Independent per-track tfdt zeroing destroys relative timing when separate HLS playlists have different wall-clock starting offsets (up to ~2s).

Fix:
- Extract timescale from init segments (moov/trak/mdia/mdhd) for both tracks
- Convert each track's first tfdt to real seconds using its timescale
- Find the common minimum presentation origin
- Compute per-track shifts that preserve relative timing